### PR TITLE
fix(schema): allow string values in `recipeCategory`

### DIFF
--- a/docs/content/schema/recipe.md
+++ b/docs/content/schema/recipe.md
@@ -129,7 +129,7 @@ export interface RecipeSimple extends Thing {
   /**
    * A string describing the category of the recipe.
    */
-  recipeCategory?: string | 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter'
+  recipeCategory?: 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter' | (string & Record<never, never>)
   /**
    * A RestrictedDiet node, with a value (or array of values
    */

--- a/docs/content/schema/recipe.md
+++ b/docs/content/schema/recipe.md
@@ -127,9 +127,9 @@ export interface RecipeSimple extends Thing {
    */
   recipeCuisine?: string
   /**
-   * The category of the recipe.
+   * A string describing the category of the recipe.
    */
-  recipeCategory?: 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter'
+  recipeCategory?: string | 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter'
   /**
    * A RestrictedDiet node, with a value (or array of values
    */

--- a/packages/unhead-schema-org/src/nodes/Recipe/index.ts
+++ b/packages/unhead-schema-org/src/nodes/Recipe/index.ts
@@ -73,7 +73,7 @@ export interface RecipeSimple extends Thing {
   /**
    * The category of the recipe.
    */
-  recipeCategory?: 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter' |  | (string & Record<never, never>)
+  recipeCategory?: 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter' | (string & Record<never, never>)
   /**
    * A RestrictedDiet node, with a value (or array of values
    */

--- a/packages/unhead-schema-org/src/nodes/Recipe/index.ts
+++ b/packages/unhead-schema-org/src/nodes/Recipe/index.ts
@@ -73,7 +73,7 @@ export interface RecipeSimple extends Thing {
   /**
    * The category of the recipe.
    */
-  recipeCategory?: 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter'
+  recipeCategory?: string | 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter'
   /**
    * A RestrictedDiet node, with a value (or array of values
    */

--- a/packages/unhead-schema-org/src/nodes/Recipe/index.ts
+++ b/packages/unhead-schema-org/src/nodes/Recipe/index.ts
@@ -73,7 +73,7 @@ export interface RecipeSimple extends Thing {
   /**
    * The category of the recipe.
    */
-  recipeCategory?: string | 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter'
+  recipeCategory?: 'Appetizer' | 'Breakfast' | 'Brunch' | 'Dessert' | 'Dinner' | 'Drink' | 'Lunch' | 'Main course' | 'Sauce' | 'Side dish' | 'Snack' | 'Starter' |  | (string & Record<never, never>)
   /**
    * A RestrictedDiet node, with a value (or array of values
    */


### PR DESCRIPTION
### Description
According to the [schema.org documentation](https://schema.org/recipeCategory), the recipeCategory can be any string value.
